### PR TITLE
Dockerfile: broken plink dl link; use github code instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,19 @@ wget \
 r-base \
 unzip
 
-RUN cd /usr/bin/ && \
-wget https://www.cog-genomics.org/static/bin/plink180221/plink_linux_x86_64.zip && \
-unzip plink_linux_x86_64.zip && \
-rm plink_linux_x86_64.zip
+# plink build dependencies
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  zlib1g-dev
+# plink 2.0 alpha 1 final
+# https://github.com/chrchang/plink-ng/releases/tag/b0cec5e
+RUN cd /tmp \
+  && git clone --branch b0cec5e https://github.com/chrchang/plink-ng \
+  && cd plink-ng/2.0/build_dynamic/ \
+  && sed -i "s/ZSTD_O2 = 1.*/ZSTD_O2 = 0/"   Makefile \
+  && sed -i "s/NO_LAPACK =.*/NO_LAPACK = 1/" Makefile \
+  && make -j 5 \
+  && cp plink2 /usr/bin/
 
 RUN pip install \
 numpy==1.12.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,21 @@ unzip
 # plink build dependencies
 RUN apt-get update && apt-get install -y \
   build-essential \
+  curl \
+  libatlas-base-dev \
+  liblapack-dev \
   zlib1g-dev
 # plink 2.0 alpha 1 final
 # https://github.com/chrchang/plink-ng/releases/tag/b0cec5e
 RUN cd /tmp \
   && git clone --branch b0cec5e https://github.com/chrchang/plink-ng \
   && cd plink-ng/2.0/build_dynamic/ \
-  && sed -i "s/ZSTD_O2 = 1.*/ZSTD_O2 = 0/"   Makefile \
-  && sed -i "s/NO_LAPACK =.*/NO_LAPACK = 1/" Makefile \
+  && sed -i "s/ZSTD_O2 = 1.*/ZSTD_O2 = 0/" Makefile \
   && make -j 5 \
-  && cp plink2 /usr/bin/
+  && cp plink2 /usr/bin/ \
+  && cd ../../1.9 \
+  && bash plink_first_compile \
+  && cp plink /usr/bin
 
 RUN pip install \
 numpy==1.12.1 \


### PR DESCRIPTION
Plink download link [1] used in Dockerfile gives 404. 

This PR fetches latest tagged release (2.0 alpha 1 final) from github. plink2 bin is complied and placed in `/usr/bin`.

[1] https://www.cog-genomics.org/static/bin/plink180221/plink_linux_x86_64.zip