### PR TITLE
dockerignore: fix for singularity dir - is used by docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 testdata/*
 data/*
-singularity/*
+singularity/GRSworkflow.simg


### PR DESCRIPTION
I dockerignored too much last time